### PR TITLE
Add Dozzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.MM.patch` scheme.
+and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
 ## Unreleased
+
+### Added
+
+- Added a new `core/apps/dozzle` package for viewing Docker container logs.
 
 ## v2023.9.0 - 2023-12-30
 

--- a/core/apps/dozzle/compose-frontend.yml
+++ b/core/apps/dozzle/compose-frontend.yml
@@ -3,12 +3,11 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_BASEURL=/ps/data/browse
-      - FB_NOAUTH=true
+      - DOZZLE_BASE=/admin/dozzle
     labels:
       caddy: :80
-      caddy.redir: /ps/data/browse /ps/data/browse/
-      caddy.handle: /ps/data/browse/*
+      caddy.redir: /admin/dozzle /admin/dozzle/
+      caddy.handle: /admin/dozzle/*
       caddy.handle.reverse_proxy: "{{upstreams 8080}}"
 
 networks:

--- a/core/apps/dozzle/compose.yml
+++ b/core/apps/dozzle/compose.yml
@@ -1,0 +1,12 @@
+services:
+  server:
+    image: amir20/dozzle:v6.0.6
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DOZZLE_ENABLE_ACTIONS=true
+
+networks:
+  default:
+    name: none
+    external: true

--- a/core/apps/dozzle/forklift-package.yml
+++ b/core/apps/dozzle/forklift-package.yml
@@ -1,0 +1,38 @@
+package:
+  description: Log viewer for Docker
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: MIT
+  sources:
+    - https://github.com/amir20/dozzle
+
+deployment:
+  compose-files: [compose.yml]
+
+features:
+  frontend:
+    description: Provides access to the GUI
+    compose-files: [compose-frontend.yml]
+    tags:
+      - device-portal-name=App log viewer
+      - device-portal-description=Provides an interface to view logs of apps installed on the PlanktoScope
+      - device-portal-type=Browser applications
+      - device-portal-purpose=System administration and troubleshooting
+      - device-portal-entrypoint=/admin/dozzle/
+    requires:
+      networks:
+        - description: Overlay network for Caddy to connect to upstream services
+          name: caddy-ingress
+      services:
+        - tags: [caddy-docker-proxy]
+          port: 80
+          protocol: http
+    provides:
+      services:
+        - description: The Dozzle Docker log viewer
+          port: 80
+          protocol: http
+          paths:
+            - /admin/dozzle
+            - /admin/dozzle/*

--- a/core/apps/filebrowser-root/compose-frontend.yml
+++ b/core/apps/filebrowser-root/compose-frontend.yml
@@ -3,6 +3,7 @@ services:
     networks:
       - caddy-ingress
     environment:
+      - FB_PORT=8080
       - FB_BASEURL=/admin/fs
       - FB_NOAUTH=true
     labels:

--- a/core/apps/filebrowser-root/compose-frontend.yml
+++ b/core/apps/filebrowser-root/compose-frontend.yml
@@ -3,14 +3,13 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80
       - FB_BASEURL=/admin/fs
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /admin/fs /admin/fs/
       caddy.handle: /admin/fs/*
-      caddy.handle.reverse_proxy: "{{upstreams 80}}"
+      caddy.handle.reverse_proxy: "{{upstreams 8080}}"
 
 networks:
   caddy-ingress:

--- a/core/apps/filebrowser-root/compose-frontend.yml
+++ b/core/apps/filebrowser-root/compose-frontend.yml
@@ -3,7 +3,7 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 80
+      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 8080
       - FB_BASEURL=/admin/fs
       - FB_NOAUTH=true
     labels:

--- a/core/apps/filebrowser-root/compose-frontend.yml
+++ b/core/apps/filebrowser-root/compose-frontend.yml
@@ -3,14 +3,14 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=8080
+      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 80
       - FB_BASEURL=/admin/fs
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /admin/fs /admin/fs/
       caddy.handle: /admin/fs/*
-      caddy.handle.reverse_proxy: "{{upstreams 8080}}"
+      caddy.handle.reverse_proxy: "{{upstreams 80}}"
 
 networks:
   caddy-ingress:

--- a/core/apps/planktoscope/device-portal/compose.yml
+++ b/core/apps/planktoscope/device-portal/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-portal:0.1.12
+    image: ghcr.io/planktoscope/device-portal:0.1.13
 
 networks:
   default:

--- a/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
@@ -3,14 +3,14 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=8080
+      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 80
       - FB_BASEURL=/admin/ps/device-backend-logs/browse
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /admin/ps/device-backend-logs/browse /admin/ps/device-backend-logs/browse/
       caddy.handle: /admin/ps/device-backend-logs/browse/*
-      caddy.handle.reverse_proxy: "{{upstreams 8080}}"
+      caddy.handle.reverse_proxy: "{{upstreams 80}}"
 
 networks:
   caddy-ingress:

--- a/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
@@ -3,7 +3,7 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 80
+      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 8080
       - FB_BASEURL=/admin/ps/device-backend-logs/browse
       - FB_NOAUTH=true
     labels:

--- a/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
@@ -3,14 +3,13 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80
       - FB_BASEURL=/admin/ps/device-backend-logs/browse
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /admin/ps/device-backend-logs/browse /admin/ps/device-backend-logs/browse/
       caddy.handle: /admin/ps/device-backend-logs/browse/*
-      caddy.handle.reverse_proxy: "{{upstreams 80}}"
+      caddy.handle.reverse_proxy: "{{upstreams 8080}}"
 
 networks:
   caddy-ingress:

--- a/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/compose-frontend.yml
@@ -3,6 +3,7 @@ services:
     networks:
       - caddy-ingress
     environment:
+      - FB_PORT=8080
       - FB_BASEURL=/admin/ps/device-backend-logs/browse
       - FB_NOAUTH=true
     labels:

--- a/core/apps/planktoscope/filebrowser-datasets/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-datasets/compose-frontend.yml
@@ -3,6 +3,7 @@ services:
     networks:
       - caddy-ingress
     environment:
+      - FB_PORT=8080
       - FB_BASEURL=/ps/data/browse
       - FB_NOAUTH=true
     labels:

--- a/core/apps/planktoscope/filebrowser-datasets/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-datasets/compose-frontend.yml
@@ -3,14 +3,14 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=8080
+      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 80
       - FB_BASEURL=/ps/data/browse
       - FB_NOAUTH=true
     labels:
       caddy: :80
       caddy.redir: /ps/data/browse /ps/data/browse/
       caddy.handle: /ps/data/browse/*
-      caddy.handle.reverse_proxy: "{{upstreams 8080}}"
+      caddy.handle.reverse_proxy: "{{upstreams 80}}"
 
 networks:
   caddy-ingress:

--- a/core/apps/planktoscope/filebrowser-datasets/compose-frontend.yml
+++ b/core/apps/planktoscope/filebrowser-datasets/compose-frontend.yml
@@ -3,7 +3,7 @@ services:
     networks:
       - caddy-ingress
     environment:
-      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 80
+      - FB_PORT=80 # for some reason filebrowser doesn't work if this is port 8080
       - FB_BASEURL=/ps/data/browse
       - FB_NOAUTH=true
     labels:


### PR DESCRIPTION
This PR adds Dozzle as a Docker container log viewer, as an alternative to Portainer.