### PR TITLE
Split up Grafana features, improve dependency relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Upgraded `core/apps/portainer`'s container image from 2.18.4 to 2.19.4.
 - Upgraded `core/infra/caddy-ingress`'s container image from 2.8.6 to 2.8.10.
 - Upgraded `core/infra/mosquitto`'s container image from 2.0.17 to 2.0.18.
+- Changed some package resource dependency relationships to be nonblocking for `plt apply` and `dev plt apply`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Added a new `core/infra/prometheus` package for handling all Prometheus metrics.
 - Added a new `core/apps/node-exporter` package for generating Prometheus metrics about the state of the host system.
 - Added a new `core/apps/grafana` package for visualizing Prometheus metrics, including a dashboard summarizing the state of the host system.
-- Exposed the `/ps/node-red-v2/api/*` path for prototyping HTTP API endpoints
+- Exposed the `/ps/node-red-v2/api/*` path for prototyping HTTP API endpoints.
+- Added `requires-grafana-host-summary-dashboard` and `requires-filebrowser-datasets` feature flags to `/core/apps/planktoscope/node-red-dashboard` to express resource requirements for apps embedded in the Node-RED dashboard.
 
 ### Changed
 

--- a/core/apps/grafana/compose-dashboard-host-summary.yml
+++ b/core/apps/grafana/compose-dashboard-host-summary.yml
@@ -1,0 +1,5 @@
+services:
+  server:
+    volumes:
+      - ./provisioning/dashboards/host-summary.yml:/provisioning/dashboards/host-summary.yml
+      - ./dashboards/host-summary.json:/provisioned-dashboards/host-summary.json

--- a/core/apps/grafana/compose-datasource-prometheus.yml
+++ b/core/apps/grafana/compose-datasource-prometheus.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    volumes:
+      - ./provisioning/datasources/prometheus.yml:/provisioning/datasources/prometheus.yml

--- a/core/apps/grafana/compose.yml
+++ b/core/apps/grafana/compose.yml
@@ -3,8 +3,6 @@ services:
     image: grafana/grafana-oss:10.1.6
     volumes:
       - server-data:/var/lib/grafana
-      - ./provisioning:/provisioning
-      - ./dashboards:/provisioned-dashboards
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:

--- a/core/apps/grafana/forklift-package.yml
+++ b/core/apps/grafana/forklift-package.yml
@@ -50,6 +50,7 @@ features:
           paths:
             - /admin/prometheus
             - /admin/prometheus/*
+          nonblocking: true
   host-summary-dashboard:
     description: Provides a dashboard to summarize node-exporter metrics; includes prometheus-datasource
     compose-files: [compose-datasource-prometheus.yml, compose-dashboard-host-summary.yml]
@@ -61,9 +62,11 @@ features:
           paths:
             - /admin/prometheus
             - /admin/prometheus/*
+          nonblocking: true
         - description: Metrics from the Prometheus node-exporter app
           tags: [node-exporter]
           protocol: prometheus-metrics
+          nonblocking: true
     provides:
       services:
         - description: Dashboard with summary of host metrics

--- a/core/apps/grafana/forklift-package.yml
+++ b/core/apps/grafana/forklift-package.yml
@@ -39,3 +39,36 @@ features:
   no-login:
     description: Allows full access without user management or login
     compose-files: [compose-no-login.yml]
+  prometheus-datasource:
+    description: Provides integration with a Prometheus server
+    compose-files: [compose-datasource-prometheus.yml]
+    requires:
+      services:
+        - description: Prometheus server
+          port: 80
+          protocol: http
+          paths:
+            - /admin/prometheus
+            - /admin/prometheus/*
+  host-summary-dashboard:
+    description: Provides a dashboard to summarize node-exporter metrics; includes prometheus-datasource
+    compose-files: [compose-datasource-prometheus.yml, compose-dashboard-host-summary.yml]
+    requires:
+      services:
+        - description: Prometheus server
+          port: 80
+          protocol: http
+          paths:
+            - /admin/prometheus
+            - /admin/prometheus/*
+        - description: Metrics from the Prometheus node-exporter app
+          tags: [node-exporter]
+          protocol: prometheus-metrics
+    provides:
+      services:
+        - description: Dashboard with summary of host metrics
+          tags: [dashboard-host-summary]
+          port: 80
+          protocol: http
+          paths:
+            - /admin/grafana/d/host-summary/*

--- a/core/apps/node-exporter/forklift-package.yml
+++ b/core/apps/node-exporter/forklift-package.yml
@@ -20,9 +20,12 @@ deployment:
         port: 9100
         protocol: tcp
     services:
-      - description: Prometheus metrics
+      - description: Prometheus metrics endpoint
         port: 9100
-        application: prometheus-metrics
         protocol: http
         paths:
-          - /*
+          - /
+          - /metrics
+      - description: node-exporter Prometheus metrics
+        tags: [node-exporter]
+        protocol: prometheus-metrics

--- a/core/apps/planktoscope/device-backend/controller/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/controller/forklift-package.yml
@@ -45,6 +45,7 @@ deployment:
       - tags: [mqtt-broker]
         port: 1883
         protocol: mqtt
+        nonblocking: false # absence of the MQTT server is not yet handled
 
 features:
   camera-preview-stream-mjpeg:

--- a/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
@@ -44,6 +44,7 @@ deployment:
       - tags: [mqtt-broker]
         port: 1883
         protocol: mqtt
+        nonblocking: false # absence of the MQTT server is not yet handled
 
 features:
   object-stream-mjpeg:

--- a/core/apps/planktoscope/node-red-dashboard/forklift-package.yml
+++ b/core/apps/planktoscope/node-red-dashboard/forklift-package.yml
@@ -31,6 +31,10 @@ deployment:
   compose-files: [compose.yml]
   requires:
     services:
+      - tags: [mqtt-broker]
+        port: 1883
+        protocol: mqtt
+        nonblocking: true
       - tags: [planktoscope-api-v2]
         port: 1883
         protocol: mqtt
@@ -122,6 +126,7 @@ features:
           protocol: http
           paths:
             - /admin/grafana/d/host-summary/*
+          nonblocking: true
   requires-filebrowser-datasets:
     requires:
       services:
@@ -131,3 +136,4 @@ features:
           paths:
             - /ps/data/browse
             - /ps/data/browse/*
+          nonblocking: false # absence of the filebrowser server is not yet handled

--- a/core/apps/planktoscope/node-red-dashboard/forklift-package.yml
+++ b/core/apps/planktoscope/node-red-dashboard/forklift-package.yml
@@ -112,3 +112,22 @@ features:
           paths:
             - /ps/node-red-v2/ui
             - /ps/node-red-v2/ui/*
+  requires-grafana-host-summary-dashboard:
+    description: Adds a resource requirement for a host summary Grafana dashboard
+    requires:
+      services:
+        - description: Dashboard with summary of host metrics
+          tags: [dashboard-host-summary]
+          port: 80
+          protocol: http
+          paths:
+            - /admin/grafana/d/host-summary/*
+  requires-filebrowser-datasets:
+    requires:
+      services:
+        - description: Adds a resource requirement for a dataset filebrowser
+          port: 80
+          protocol: http
+          paths:
+            - /ps/data/browse
+            - /ps/data/browse/*


### PR DESCRIPTION
This PR improves the decomposition of functionalities in the `core/apps/grafana` package and adds some more resource requirement dependencies to `core/apps/ps/node-red-dashboard` for embedded frames (the datasets filebrowser and the grafana dashboard). This PR also makes some resource requirements non-blocking to take advantage of a new `nonblocking` field added in https://github.com/PlanktoScope/forklift/pull/111 .