### PR TITLE
Provision dhcpcd config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Added `requires-grafana-host-summary-dashboard` and `requires-filebrowser-datasets` feature flags to `/core/apps/planktoscope/node-red-dashboard` to express resource requirements for apps embedded in the Node-RED dashboard.
 - Added scripts for the PlanktoScope distro in `core/host/networking/autohotspot`, `core/host/interface-forwarding`, `core/host/planktoscope/gpio-init`, and `core/host/planktoscope/machine-name`.
 - Added the Node-RED settings file to `core/apps/planktoscope/node-red-dashboard`.
+- Added the dhcpcd config file to `core/apps/networking/dhcpcd`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Added `requires-grafana-host-summary-dashboard` and `requires-filebrowser-datasets` feature flags to `/core/apps/planktoscope/node-red-dashboard` to express resource requirements for apps embedded in the Node-RED dashboard.
 - Added scripts for the PlanktoScope distro in `core/host/networking/autohotspot`, `core/host/interface-forwarding`, `core/host/planktoscope/gpio-init`, and `core/host/planktoscope/machine-name`.
 - Added the Node-RED settings file to `core/apps/planktoscope/node-red-dashboard`.
-- Added support for routing more network interfaces in the `core/host/interface-forwarding` package's `enable-interface-forwarding.sh` scsript.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Exposed the `/ps/node-red-v2/api/*` path for prototyping HTTP API endpoints.
 - Added `requires-grafana-host-summary-dashboard` and `requires-filebrowser-datasets` feature flags to `/core/apps/planktoscope/node-red-dashboard` to express resource requirements for apps embedded in the Node-RED dashboard.
 - Added scripts for the PlanktoScope distro in `core/host/networking/autohotspot`, `core/host/interface-forwarding`, `core/host/planktoscope/gpio-init`, and `core/host/planktoscope/machine-name`.
-- Added the Node-RED settings file to `core/apps/planktoscope/node-red-dashboard`
+- Added the Node-RED settings file to `core/apps/planktoscope/node-red-dashboard`.
+- Added support for routing more network interfaces in the `core/host/interface-forwarding` package's `enable-interface-forwarding.sh` scsript.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Added `requires-grafana-host-summary-dashboard` and `requires-filebrowser-datasets` feature flags to `/core/apps/planktoscope/node-red-dashboard` to express resource requirements for apps embedded in the Node-RED dashboard.
 - Added scripts for the PlanktoScope distro in `core/host/networking/autohotspot`, `core/host/interface-forwarding`, `core/host/planktoscope/gpio-init`, and `core/host/planktoscope/machine-name`.
 - Added the Node-RED settings file to `core/apps/planktoscope/node-red-dashboard`.
-- Added the dhcpcd config file to `core/apps/networking/dhcpcd`.
+- Added the dhcpcd config file to `core/host/networking/dhcpcd`.
 
 ### Changed
 

--- a/core/host/networking/dhcpcd/dhcpcd.conf
+++ b/core/host/networking/dhcpcd/dhcpcd.conf
@@ -1,0 +1,67 @@
+# See dhcpcd.conf(5) for details.
+
+# Allow users of this group to interact with dhcpcd via the control socket.
+#controlgroup wheel
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
+# Most distributions have NTP support.
+#option ntp_servers
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate SLAAC address using the Hardware Address of the interface
+#slaac hwaddr
+# OR generate Stable Private IPv6 Addresses based from the DUID
+slaac private
+
+noarp
+
+profile static_eth0
+static ip_address=192.168.5.1/24
+static routers=192.168.5.1
+static domain_name_servers=192.168.5.1
+nogateway # don't install any default routes
+interface eth0
+fallback static_eth0
+
+profile static_usb0
+static ip_address=192.168.6.1/24
+static routers=192.168.6.1
+static domain_name_servers=192.168.6.1
+nogateway # don't install any default routes
+interface usb0
+fallback static_usb0
+timeout 0 # allow hot-plugging of this interface
+
+profile static_eth1
+static ip_address=192.168.7.1/24
+static routers=192.168.7.1
+static domain_name_servers=192.168.7.1
+nogateway # don't install any default routes
+interface eth1
+fallback static_eth1

--- a/core/host/networking/dhcpcd/dhcpcd.conf
+++ b/core/host/networking/dhcpcd/dhcpcd.conf
@@ -41,11 +41,16 @@ slaac private
 
 noarp
 
+# Ignore virtual interfaces made by docker:
+denyinterfaces veth*
+denyinterfaces br-*
+
 profile static_eth0
 static ip_address=192.168.5.1/24
 static routers=192.168.5.1
 static domain_name_servers=192.168.5.1
 nogateway # don't install any default routes
+
 interface eth0
 fallback static_eth0
 
@@ -54,14 +59,15 @@ static ip_address=192.168.6.1/24
 static routers=192.168.6.1
 static domain_name_servers=192.168.6.1
 nogateway # don't install any default routes
+
 interface usb0
 fallback static_usb0
-timeout 0 # allow hot-plugging of this interface
 
 profile static_eth1
 static ip_address=192.168.7.1/24
 static routers=192.168.7.1
 static domain_name_servers=192.168.7.1
 nogateway # don't install any default routes
+
 interface eth1
 fallback static_eth1

--- a/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
+++ b/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
@@ -31,10 +31,10 @@ for i in ${!joined_interfaces[@]}; do
 done
 
 # Redirect external incoming traffic bound for the device to 127.0.0.1
-redirect_inbound usb0 192.168.3.1
-redirect_inbound eth0 192.168.4.1
-redirect_inbound wlan0 192.168.5.1
-redirect_inbound wlan1 192.168.6.1
-redirect_inbound eth1 192.168.12.1
-redirect_inbound eth2 192.168.13.1
-redirect_inbound eth3 192.168.14.1
+redirect_inbound usb0 192.168.2.1
+redirect_inbound wlan1 192.168.3.1
+redirect_inbound wlan0 192.168.4.1
+redirect_inbound eth0 192.168.5.1
+redirect_inbound eth1 192.168.6.1
+redirect_inbound eth2 192.168.7.1
+redirect_inbound eth3 192.168.8.1

--- a/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
+++ b/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
@@ -16,11 +16,12 @@ redirect_inbound() {
   local interface="$1"
   local ipaddr="$2"
 
-  iptables -t nat -A PREROUTING -i "$interface" -d "$ipaddr" -j DNA --to-destination 127.0.0.1
+  iptables -t nat -A PREROUTING -i "$interface" -d "$ipaddr" -j DNAT --to-destination 127.0.0.1
 }
 
 # Route packets between network interfaces
-joined_interfaces = (wlan0 wlan1 eth0 eth1 eth2 eth3 eth4 usb0 usb1 usb2 usb3)
+# Note: system performance degrades too much if we add too many interfaces here
+joined_interfaces=(wlan0 wlan1 eth0 eth1 usb0)
 for i in ${!joined_interfaces[@]}; do
   for j in ${!joined_interfaces[@]}; do
     if [ "$j" -le "$i" ]; then
@@ -36,9 +37,3 @@ redirect_inbound wlan0 192.168.4.1
 redirect_inbound eth0 192.168.5.1
 redirect_inbound usb0 192.168.6.1
 redirect_inbound eth1 192.168.7.1
-redirect_inbound usb1 192.168.8.1
-redirect_inbound eth2 192.168.9.1
-redirect_inbound usb2 192.168.10.1
-redirect_inbound eth3 192.168.11.1
-redirect_inbound usb3 192.168.12.1
-redirect_inbound eth4 192.168.13.1

--- a/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
+++ b/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
@@ -1,13 +1,40 @@
 #!/bin/bash -eux
 
-# Route packets between wlan0 and eth0
-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-iptables -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT
-iptables -A FORWARD -i wlan0 -o eth0 -j ACCEPT
-iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
-iptables -A FORWARD -i wlan0 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT
-iptables -A FORWARD -i eth0 -o wlan0 -j ACCEPT
+route_between() {
+  local interface_a="$1"
+  local interface_b="$2"
 
-# Redirect external incoming traffic bound for 192.168.4.1 and 192.168.5.1 to 127.0.0.1
-iptables -t nat -A PREROUTING -i eth0 -d 192.168.4.1 -j DNAT --to-destination 127.0.0.1
-iptables -t nat -A PREROUTING -i wlan0 -d 192.168.5.1 -j DNAT --to-destination 127.0.0.1
+  iptables -t nat -A POSTROUTING -o "$1" -j MASQUERADE
+  iptables -A FORWARD -i "$1" -o "$2" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  iptables -A FORWARD -i "$2" -o "$1" -j ACCEPT
+  iptables -t nat -A POSTROUTING -o "$2" -j MASQUERADE
+  iptables -A FORWARD -i "$2" -o "$1" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  iptables -A FORWARD -i "$1" -o "$2" -j ACCEPT
+}
+
+redirect_inbound() {
+  local interface="$1"
+  local ipaddr="$2"
+
+  iptables -t nat -A PREROUTING -i "$interface" -d "$ipaddr" -j DNA --to-destination 127.0.0.1
+}
+
+# Route packets between network interfaces
+joined_interfaces = (usb0 eth0 wlan0 wlan1 eth1 eth2 eth3)
+for i in ${!joined_interfaces[@]}; do
+  for j in ${!joined_interfaces[@]}; do
+    if [ "$j" -le "$i" ]; then
+      continue
+    fi
+    route_between "${joined_interfaces[$i]}" "${joined_interfaces[$j]}"
+  done
+done
+
+# Redirect external incoming traffic bound for the device to 127.0.0.1
+redirect_inbound usb0 192.168.3.1
+redirect_inbound eth0 192.168.4.1
+redirect_inbound wlan0 192.168.5.1
+redirect_inbound wlan1 192.168.6.1
+redirect_inbound eth1 192.168.12.1
+redirect_inbound eth2 192.168.13.1
+redirect_inbound eth3 192.168.14.1

--- a/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
+++ b/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
@@ -20,7 +20,7 @@ redirect_inbound() {
 }
 
 # Route packets between network interfaces
-joined_interfaces = (usb0 eth0 wlan0 wlan1 eth1 eth2 eth3)
+joined_interfaces = (wlan0 wlan1 eth0 eth1 eth2 eth3 usb0 usb1 usb2 usb3)
 for i in ${!joined_interfaces[@]}; do
   for j in ${!joined_interfaces[@]}; do
     if [ "$j" -le "$i" ]; then
@@ -31,10 +31,13 @@ for i in ${!joined_interfaces[@]}; do
 done
 
 # Redirect external incoming traffic bound for the device to 127.0.0.1
-redirect_inbound usb0 192.168.2.1
 redirect_inbound wlan1 192.168.3.1
 redirect_inbound wlan0 192.168.4.1
 redirect_inbound eth0 192.168.5.1
-redirect_inbound eth1 192.168.6.1
-redirect_inbound eth2 192.168.7.1
-redirect_inbound eth3 192.168.8.1
+redirect_inbound usb0 192.168.6.1
+redirect_inbound eth1 192.168.7.1
+redirect_inbound usb1 192.168.8.1
+redirect_inbound eth2 192.168.9.1
+redirect_inbound usb2 192.168.10.1
+redirect_inbound eth3 192.168.11.1
+redirect_inbound usb3 192.168.12.1

--- a/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
+++ b/core/host/networking/interface-forwarding/enable-interface-forwarding.sh
@@ -20,7 +20,7 @@ redirect_inbound() {
 }
 
 # Route packets between network interfaces
-joined_interfaces = (wlan0 wlan1 eth0 eth1 eth2 eth3 usb0 usb1 usb2 usb3)
+joined_interfaces = (wlan0 wlan1 eth0 eth1 eth2 eth3 eth4 usb0 usb1 usb2 usb3)
 for i in ${!joined_interfaces[@]}; do
   for j in ${!joined_interfaces[@]}; do
     if [ "$j" -le "$i" ]; then
@@ -41,3 +41,4 @@ redirect_inbound eth2 192.168.9.1
 redirect_inbound usb2 192.168.10.1
 redirect_inbound eth3 192.168.11.1
 redirect_inbound usb3 192.168.12.1
+redirect_inbound eth4 192.168.13.1


### PR DESCRIPTION
This PR provides a config file for DHCPCD in the `core/host/networking/dhcpcd` package, as part of https://github.com/PlanktoScope/PlanktoScope/issues/349. This config includes support for `usb0`, `wlan0`, and `eth1` network interfaces, both for accessing the PlanktoScope browser apps and for sharing  internet access.