### PR TITLE
Make the backend segmenter package deploy as a Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,15 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Changed
 
 - (Breaking change) Changed the `core/apps/planktoscope/device-backend/processing/segmenter` package to deploy the segmenter as a Docker container rather than expecting it to exist on the host.
+- (Breaking change) Reorganized packages in `core/host`.
+- Now the `core/apps/planktoscope/filebrowser-backend-logs` package has a resource dependency on one or more deployments which save logs to the location expected by the package.
+- Changed some package resource dependency relationships to be nonblocking for `plt apply` and `dev plt apply`.
 - Upgraded `core/apps/planktoscope/device-portal`'s container image from v0.1.12 to v0.1.14.
 - Upgraded all packages which use the `alpine` container image from 3.18.3 to 3.19.0.
 - Upgraded all packages which use the `filebrowser/filebrowser` container image from v2.24.2 to v2.27.0.
 - Upgraded `core/apps/portainer`'s container image from 2.18.4 to 2.19.4.
 - Upgraded `core/infra/caddy-ingress`'s container image from 2.8.6 to 2.8.10.
 - Upgraded `core/infra/mosquitto`'s container image from 2.0.17 to 2.0.18.
-- Changed some package resource dependency relationships to be nonblocking for `plt apply` and `dev plt apply`.
-- (Breaking change) Reorganized packages in `core/host`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ### Changed
 
+- (Breaking change) Changed the `core/apps/planktoscope/device-backend/processing/segmenter` package to deploy the segmenter as a Docker container rather than expecting it to exist on the host.
 - Upgraded `core/apps/planktoscope/device-portal`'s container image from v0.1.12 to v0.1.14.
 - Upgraded all packages which use the `alpine` container image from 3.18.3 to 3.19.0.
 - Upgraded all packages which use the `filebrowser/filebrowser` container image from v2.24.2 to v2.27.0.
@@ -30,6 +31,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - Upgraded `core/infra/mosquitto`'s container image from 2.0.17 to 2.0.18.
 - Changed some package resource dependency relationships to be nonblocking for `plt apply` and `dev plt apply`.
 - (Breaking change) Reorganized packages in `core/host`.
+
+### Removed
+
+- (Breaking change) Removed `core/apps/planktoscope/device-backend/processing/segmenter`'s MJPEG stream service on host port 8001, since it can now be accessed via Docker networking.
 
 ### Fixed
 

--- a/core/apps/planktoscope/device-backend/controller/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/controller/forklift-package.yml
@@ -37,6 +37,11 @@ host:
           - /status/pump
           - /status/focus
           - /status/imager
+      - description: Controller service logs
+        tags: [log-files]
+        protocol: filesystem # FIXME: filesystem entities should probably be a separate resource type
+        paths:
+          - /home/pi/device-backend-logs/controller
 
 deployment:
   compose-files: [compose.yml]

--- a/core/apps/planktoscope/device-backend/controller/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/controller/forklift-package.yml
@@ -41,6 +41,7 @@ host:
         tags: [log-files]
         protocol: filesystem # FIXME: filesystem entities should probably be a separate resource type
         paths:
+          - /home/pi/device-backend-logs
           - /home/pi/device-backend-logs/controller
 
 deployment:

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
@@ -1,0 +1,5 @@
+services:
+  server:
+    volumes:
+      - /var/lib/planktoscope/machine-name:/var/lib/planktoscope/machine-name
+      - /home/pi/develop/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
@@ -2,4 +2,5 @@ services:
   server:
     volumes:
       - /var/lib/planktoscope/machine-name:/var/lib/planktoscope/machine-name
-      - /home/pi/develop/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter
+      - /home/pi/data:/home/pi/data
+      - /home/pi/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
@@ -1,6 +1,5 @@
 services:
   server:
-    user: pi
     volumes:
       - /var/lib/planktoscope/machine-name:/var/lib/planktoscope/machine-name
       - /home/pi/data:/home/pi/data

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-deploy.yml
@@ -1,5 +1,6 @@
 services:
   server:
+    user: pi
     volumes:
       - /var/lib/planktoscope/machine-name:/var/lib/planktoscope/machine-name
       - /home/pi/data:/home/pi/data

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-data.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-data.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    volumes:
+      - ~/.local/share/planktoscope/data:/home/pi/data

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-logs.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-logs.yml
@@ -1,4 +1,4 @@
 services:
   server:
     volumes:
-      - ~/.local/lib/planktoscope/develop/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter
+      - ~/.local/share/planktoscope/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-logs.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-logs.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    volumes:
+      - ~/.local/lib/planktoscope/develop/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-machinename.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-machinename.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    volumes:
+      - ~/.local/lib/planktoscope/machine-name:/var/lib/planktoscope/machine-name

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-machinename.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-machinename.yml
@@ -1,4 +1,4 @@
 services:
   server:
     volumes:
-      - ~/.local/lib/planktoscope/machine-name:/var/lib/planktoscope/machine-name
+      - ~/.local/share/planktoscope/machine-name:/var/lib/planktoscope/machine-name

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-src.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-src.yml
@@ -1,4 +1,4 @@
 services:
   server:
     volumes:
-      - /home/pi/develop/device-backend/processing/segmenter:/home/pi/device-backend/processing/segmenter
+      - ~/.local/share/planktoscope/develop/device-backend/processing/segmenter:/home/pi/device-backend/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-src.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-src.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    volumes:
+      - /home/pi/develop/device-backend/processing/segmenter:/home/pi/device-backend/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-src.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-dev-src.yml
@@ -1,4 +1,4 @@
 services:
   server:
     volumes:
-      - ~/.local/share/planktoscope/develop/device-backend/processing/segmenter:/home/pi/device-backend/processing/segmenter
+      - ~/.local/share/planktoscope/src/device-backend/processing/segmenter:/home/pi/device-backend/processing/segmenter

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose-object-stream-mjpeg.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose-object-stream-mjpeg.yml
@@ -1,12 +1,12 @@
 services:
-  reverse-proxy-config:
+  server:
     networks:
       - caddy-ingress
     labels:
       caddy: :80
       caddy.handle_path: /ps/processing/segmenter/streams/object.mjpg
       caddy.handle_path.rewrite: "* /object.mjpg"
-      caddy.handle_path.reverse_proxy: host.docker.internal:8001
+      caddy.handle_path.reverse_proxy: "{{upstreams 8001}}"
 
 networks:
   caddy-ingress:

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,9 +1,8 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-c15a817
-    volumes:
-      - /home/pi/data:/home/pi/data
-      - /home/pi/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-af75f22
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
 networks:
   default:

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-91b2e1a
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-8d0fa7b
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,7 +1,9 @@
 services:
-  reverse-proxy-config:
-    image: alpine:3.19.0
-    command: sh -c 'while sleep 3600; do :; done'
+  server:
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-c15a817
+    volumes:
+      - /home/pi/data:/home/pi/data
+      - /home/pi/device-backend-logs/processing/segmenter:/home/pi/device-backend-logs/processing/segmenter
 
 networks:
   default:

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-f0b2c90
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-c27eddb
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-af75f22
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-1af1992
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-8d0fa7b
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-f0b2c90
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-1af1992
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-91b2e1a
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-661d59c
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-a070c89
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-c27eddb
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:sha-661d59c
     extra_hosts:
       - host.docker.internal:host-gateway
 

--- a/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
@@ -63,10 +63,13 @@ features:
     description: Adds bind mounts for the PlanktoScope distro's filesystem structure
     compose-files: [compose-deploy.yml]
   dev-machinename:
-    description: Allows a machine name to be set for development & troubleshooting
+    description: Allows a machine name to be set in a file for development & troubleshooting
     compose-files: [compose-dev-machinename.yml]
+  dev-data:
+    description: Allows the segmenter to read and write datasets
+    compose-files: [compose-dev-data.yml]
   dev-logs:
-    description: Adds a bind mount for the segmenter's logs
+    description: Allows the segmenter's logs to be accessed and saved on disk
     compose-files: [compose-dev-logs.yml]
   dev-src:
     description: Allows the source code to be overwritten from an existing codebase for development & troubleshooting

--- a/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
@@ -7,25 +7,21 @@ package:
   sources:
     - https://github.com/PlanktoScope/device-backend
 
-host:
+deployment:
+  compose-files: [compose.yml]
   tags:
     - device-portal.name=PlanktoScope object segmenter
     - device-portal.description=Provides an MQTT service on /segmenter and /status/segmenter for operating the PlanktoScope object segmenter
     - device-portal.type=Network APIs
     - device-portal.purpose=PlanktoScope operation
-  provides:
-    listeners:
-      - description: MJPEG streaming web server for the PlanktoScope object segmenter
-        port: 8001
-        protocol: tcp
+  requires:
     services:
-      - description: MJPEG stream of last segmented object from the PlanktoScope object segmenter
-        tags: [mjpeg-stream]
-        port: 8001
-        protocol: http
-        paths:
-          - /
-          - /stream.mjpg
+      - tags: [mqtt-broker]
+        port: 1883
+        protocol: mqtt
+        nonblocking: false # absence of the MQTT server is not yet handled
+  provides:
+    services:
       - description: MQTT handling of segmenter commands and broadcasting of segmenter statuses
         tags: [planktoscope-api-v2]
         port: 1883
@@ -37,25 +33,16 @@ host:
           - /status/segmenter/object_id
           - /status/segmenter/metric
 
-deployment:
-  compose-files: [compose.yml]
-  requires:
-    services:
-      - tags: [mqtt-broker]
-        port: 1883
-        protocol: mqtt
-        nonblocking: false # absence of the MQTT server is not yet handled
-
 features:
   object-stream-mjpeg:
     description: Provides access to the last segmented object MJPEG stream
     compose-files: [compose-object-stream-mjpeg.yml]
     tags:
-    - device-portal.name=PlanktoScope segmented object preview
-    - device-portal.description=Provides an MJPEG stream to preview the latest segmented object
-    - device-portal.type=Network APIs
-    - device-portal.purpose=PlanktoScope operation
-    - device-portal.entrypoint=/ps/processing/segmenter/streams/object.mjpg
+      - device-portal.name=PlanktoScope segmented object preview
+      - device-portal.description=Provides an MJPEG stream to preview the latest segmented object
+      - device-portal.type=Network APIs
+      - device-portal.purpose=PlanktoScope operation
+      - device-portal.entrypoint=/ps/processing/segmenter/streams/object.mjpg
     requires:
       networks:
         - description: Overlay network for Caddy to connect to upstream services
@@ -64,11 +51,6 @@ features:
         - tags: [caddy-docker-proxy]
           port: 80
           protocol: http
-        - tags: [mjpeg-stream]
-          port: 8001
-          protocol: http
-          paths:
-            - /stream.mjpg
     provides:
       services:
         - description: Last segmented object MJPEG stream from the segmenter
@@ -77,3 +59,6 @@ features:
           protocol: http
           paths:
             - /ps/processing/segmenter/streams/object.mjpg
+  dev-src:
+    decsription: Provides access to the source code for inspection & prototyping
+    compose-files: [compose-dev-src.yml]

--- a/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
@@ -68,6 +68,7 @@ features:
           tags: [log-files]
           protocol: filesystem # FIXME: filesystem entities should probably be a separate resource type
           paths:
+            - /home/pi/device-backend-logs/processing
             - /home/pi/device-backend-logs/processing/segmenter
   dev-machinename:
     description: Allows a machine name to be set in a file for development & troubleshooting

--- a/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
@@ -62,6 +62,13 @@ features:
   deploy:
     description: Adds bind mounts for the PlanktoScope distro's filesystem structure
     compose-files: [compose-deploy.yml]
+    provides:
+      services:
+        - description: Segmenter service logs
+          tags: [log-files]
+          protocol: filesystem # FIXME: filesystem entities should probably be a separate resource type
+          paths:
+            - /home/pi/device-backend-logs/processing/segmenter
   dev-machinename:
     description: Allows a machine name to be set in a file for development & troubleshooting
     compose-files: [compose-dev-machinename.yml]

--- a/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/forklift-package.yml
@@ -1,5 +1,5 @@
 package:
-  description: Object segmenter ambiently provided by the PlanktoScope
+  description: PlanktoScope object segmenter for export to EcoTaxa
   maintainers:
     - name: Ethan Li
       email: lietk12@gmail.com
@@ -59,6 +59,15 @@ features:
           protocol: http
           paths:
             - /ps/processing/segmenter/streams/object.mjpg
+  deploy:
+    description: Adds bind mounts for the PlanktoScope distro's filesystem structure
+    compose-files: [compose-deploy.yml]
+  dev-machinename:
+    description: Allows a machine name to be set for development & troubleshooting
+    compose-files: [compose-dev-machinename.yml]
+  dev-logs:
+    description: Adds a bind mount for the segmenter's logs
+    compose-files: [compose-dev-logs.yml]
   dev-src:
-    decsription: Provides access to the source code for inspection & prototyping
+    description: Allows the source code to be overwritten from an existing codebase for development & troubleshooting
     compose-files: [compose-dev-src.yml]

--- a/core/apps/planktoscope/filebrowser-backend-logs/forklift-package.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/forklift-package.yml
@@ -11,16 +11,12 @@ deployment:
   compose-files: [compose.yml]
   requires:
     services:
-      - description: Segmenter service logs
+      - description: Device backend service logs
         tags: [log-files]
         protocol: filesystem
         paths:
-          - /home/pi/device-backend-logs/processing/segmenter
-      - description: Hardware controller service logs
-        tags: [log-files]
-        protocol: filesystem
-        paths:
-          - /home/pi/device-backend-logs/controller
+          - /home/pi/device-backend-logs
+        nonblocking: true
 
 features:
   frontend:

--- a/core/apps/planktoscope/filebrowser-backend-logs/forklift-package.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/forklift-package.yml
@@ -9,6 +9,18 @@ package:
 
 deployment:
   compose-files: [compose.yml]
+  requires:
+    services:
+      - description: Segmenter service logs
+        tags: [log-files]
+        protocol: filesystem
+        paths:
+          - /home/pi/device-backend-logs/processing/segmenter
+      - description: Hardware controller service logs
+        tags: [log-files]
+        protocol: filesystem
+        paths:
+          - /home/pi/device-backend-logs/controller
 
 features:
   frontend:


### PR DESCRIPTION
This PR makes progress on https://github.com/PlanktoScope/PlanktoScope/issues/326 by modifying the `core/apps/planktoscope/device-backend/processing/segmenter` package to deliver the Python backend segmenter as a Docker container rather than assuming that it exists on the host.