### PR TITLE
Provide the `machine-name` binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- `core/host/machine-name` now exports the `machine-name` binary into the PlanktoScope OS's overlay for `/usr`. The machine-name binary with the correct CPU architecture target for the host is selected when Forklift's downloads cache is populated.
+
 ## v2024.0.0-alpha.2 - 2024-04-25
 
 ### Added

--- a/core/host/machine-name/forklift-package.yml
+++ b/core/host/machine-name/forklift-package.yml
@@ -41,6 +41,11 @@ deployment:
         target: overlays/usr/lib/systemd/system/generate-machine-name.service
       - description: systemd service enablement for generate-machine-name.service
         target: overlays/etc/systemd/system/sysinit.target.wants/generate-machine-name.service
+      - description: machine-name binary
+        source-type: oci-image
+        url: ghcr.io/planktoscope/machine-name:0.1.3
+        source: machine-name
+        target: overlays/usr/bin/machine-name
     filesets:
       - description: Auto-generated file with the machine name
         paths:

--- a/forklift-repository.yml
+++ b/forklift-repository.yml
@@ -1,4 +1,4 @@
-forklift-version: v0.7.0
+forklift-version: v0.7.2-alpha.3
 
 repository:
   path: github.com/PlanktoScope/device-pkgs


### PR DESCRIPTION
This PR makes the `core/host/machine-name` package self-contained by having the package provide the `machine-name` binary used by the various scripts/services in that package.

This PR is associated with https://github.com/PlanktoScope/pallet-standard/pull/12 and https://github.com/PlanktoScope/PlanktoScope/pull/411.