### PR TITLE
Bump some container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 - `core/host/machine-name` now exports the `machine-name` binary into the PlanktoScope OS's overlay for `/usr`. The machine-name binary with the correct CPU architecture target for the host is selected when Forklift's downloads cache is populated.
 
+### Changed
+
+- `core/apps/filebrowser-root`: the `filebrowser/filebrowser` container image is upgraded from v2.27.0 to v2.30.0.
+- `core/apps/planktoscope/filebrowser-backend-logs`: the `filebrowser/filebrowser` container image is upgraded from v2.27.0 to v2.30.0.
+- `core/apps/planktoscope/filebrowser-datasets`: the `filebrowser/filebrowser` container image is upgraded from v2.27.0 to v2.30.0.
+
 ## v2024.0.0-alpha.2 - 2024-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - `core/apps/filebrowser-root`: the `filebrowser/filebrowser` container image is upgraded from v2.27.0 to v2.30.0.
 - `core/apps/planktoscope/filebrowser-backend-logs`: the `filebrowser/filebrowser` container image is upgraded from v2.27.0 to v2.30.0.
 - `core/apps/planktoscope/filebrowser-datasets`: the `filebrowser/filebrowser` container image is upgraded from v2.27.0 to v2.30.0.
+- `core/apps/planktoscope/device-portal`: the `ghcr.io/planktoscope/device-portal` container is upgraded from v0.2.1 to v0.2.2.
 
 ## v2024.0.0-alpha.2 - 2024-04-25
 

--- a/core/apps/filebrowser-root/compose.yml
+++ b/core/apps/filebrowser-root/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: docker.io/filebrowser/filebrowser:v2.27.0 # Note: we are skipping v2.28.0 due to https://github.com/filebrowser/filebrowser/issues/3085
+    image: docker.io/filebrowser/filebrowser:v2.30.0
     volumes:
       - /:/root
       - /:/srv # this prevents filebrowser from making an unnamed volume

--- a/core/apps/planktoscope/device-portal/compose.yml
+++ b/core/apps/planktoscope/device-portal/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-portal:0.2.1
+    image: ghcr.io/planktoscope/device-portal:0.2.2
 
 networks:
   default:

--- a/core/apps/planktoscope/filebrowser-backend-logs/compose.yml
+++ b/core/apps/planktoscope/filebrowser-backend-logs/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: docker.io/filebrowser/filebrowser:v2.27.0 # Note: we are skipping v2.28.0 due to https://github.com/filebrowser/filebrowser/issues/3085
+    image: docker.io/filebrowser/filebrowser:v2.30.0
     volumes:
       - /home/pi/device-backend-logs:/home/pi/device-backend-logs
       - /home/pi/device-backend-logs:/srv # this prevents filebrowser from making an unnamed volume

--- a/core/apps/planktoscope/filebrowser-datasets/compose.yml
+++ b/core/apps/planktoscope/filebrowser-datasets/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: docker.io/filebrowser/filebrowser:v2.27.0 # Note: we are skipping v2.28.0 due to https://github.com/filebrowser/filebrowser/issues/3085
+    image: docker.io/filebrowser/filebrowser:v2.30.0
     volumes:
       - /home/pi/data:/home/pi/data
       - /home/pi/data:/srv # this prevents filebrowser from making an unnamed volume


### PR DESCRIPTION
This PR bumps the container images of apps provided by some packages, as part of https://github.com/PlanktoScope/pallet-standard/pull/13:

- The `filebrowser/filebrowser` container image used by various apps is upgraded to v2.30.0.
- The `ghcr.io/planktoscope/device-portal` container image is bumped to v0.2.2 (for https://github.com/PlanktoScope/device-portal/pull/134)