### PR TITLE
Bump device-backend to make segmentation background transparent

### DIFF
--- a/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
+++ b/core/apps/planktoscope/device-backend/processing/segmenter/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-backend-processing-segmenter:2024.0.0-beta.1
+    image: ghcr.io/planktoscope/device-backend-processing-segmenter:pr-47
     extra_hosts:
       - host.docker.internal:host-gateway
 


### PR DESCRIPTION
This PR integrates https://github.com/PlanktoScope/device-backend/pull/47 , as part of https://github.com/PlanktoScope/pallet-standard/pull/15 .