### PR TITLE
Add `core/host/prepare-custom-image` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- `core/host/prepare-custom-image`: added a script overlaid into `/usr/libexec/prepare-custom-image` which can be run to reset the filesystem in preparation for cloning the filesystem as an SD card image.
+
 ## v2024.0.0-beta.1 - 2024-06-24
 
 ### Changed

--- a/core/host/prepare-custom-image/forklift-package.yml
+++ b/core/host/prepare-custom-image/forklift-package.yml
@@ -1,0 +1,17 @@
+package:
+  description:
+    Script to reset the filesystem in preparation for cloning it into a new SD card image.
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: Apache-2.0
+  sources:
+    - https://github.com/PlanktoScope/device-pkgs
+
+deployment:
+  provides:
+    file-exports:
+      - description:
+          Shell script to reset machine-specific files & secrets in the filesystem and prepare it to
+          be cloned as an SD card image.
+        target: overlays/usr/libexec/prepare-custom-image

--- a/core/host/prepare-custom-image/overlays/usr/libexec/prepare-custom-image
+++ b/core/host/prepare-custom-image/overlays/usr/libexec/prepare-custom-image
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+
+# Unmount overlays:
+sudo systemctl stop overlay-etc.service
+sudo systemctl stop overlay-usr.service
+
+# Clean up any unnecessary apt files:
+sudo apt-get autoremove -y
+sudo apt-get clean -y
+
+# Clear machine-id so that it will be regenerated on the next boot
+# (refer to https://www.freedesktop.org/software/systemd/man/latest/machine-id.html):
+sudo bash -c 'printf "" > /var/lib/dbus/machine-id'
+sudo bash -c 'printf "uninitialized\n" > /etc/machine-id'
+
+# Clear other secrets (refer to https://systemd.io/BUILDING_IMAGES/):
+sudo rm -f /var/lib/systemd/random-seed
+sudo rm -f /var/lib/systemd/credential.secret
+
+# Remove SSH keys:
+sudo rm -f /etc/ssh/ssh_host_*_key*
+
+# Make the OS resize the partitions to fill the SD card on the next boot:
+if ! grep 'init=/usr/lib/raspberrypi-sys-mods/firstboot' /boot/cmdline.txt > /dev/null; then
+  sudo sed 's~$~ init=/usr/lib/raspberrypi-sys-mods/firstboot~' -i /boot/cmdline.txt
+fi
+
+sudo shutdown now

--- a/core/host/prepare-custom-image/overlays/usr/libexec/prepare-custom-image
+++ b/core/host/prepare-custom-image/overlays/usr/libexec/prepare-custom-image
@@ -1,28 +1,33 @@
 #!/bin/bash -eu
 
 # Unmount overlays:
-sudo systemctl stop overlay-etc.service
-sudo systemctl stop overlay-usr.service
+systemctl stop overlay-etc.service
+systemctl stop overlay-usr.service
 
 # Clean up any unnecessary apt files:
-sudo apt-get autoremove -y
-sudo apt-get clean -y
+apt-get autoremove -y
+apt-get clean -y
 
 # Clear machine-id so that it will be regenerated on the next boot
 # (refer to https://www.freedesktop.org/software/systemd/man/latest/machine-id.html):
-sudo bash -c 'printf "" > /var/lib/dbus/machine-id'
-sudo bash -c 'printf "uninitialized\n" > /etc/machine-id'
+printf "" > /var/lib/dbus/machine-id
+printf "uninitialized\n" > /etc/machine-id
 
 # Clear other secrets (refer to https://systemd.io/BUILDING_IMAGES/):
-sudo rm -f /var/lib/systemd/random-seed
-sudo rm -f /var/lib/systemd/credential.secret
+rm -f /var/lib/systemd/random-seed
+rm -f /var/lib/systemd/credential.secret
 
 # Remove SSH keys:
-sudo rm -f /etc/ssh/ssh_host_*_key*
+rm -f /etc/ssh/ssh_host_*_key*
+rm /var/lib/overlays/overrides/etc/ssh/ssh_host_*_key
+rm /var/lib/overlays/overrides/etc/ssh/ssh_host_*_key.pub
+rm /var/lib/overlays/overrides/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service
 
 # Make the OS resize the partitions to fill the SD card on the next boot:
+rm /var/lib/overlays/overrides/etc/init.d/resize2fs_once
+rm /var/lib/overlays/overrides/etc/rc3.d/S01resize2fs_once
 if ! grep 'init=/usr/lib/raspberrypi-sys-mods/firstboot' /boot/cmdline.txt > /dev/null; then
-  sudo sed 's~$~ init=/usr/lib/raspberrypi-sys-mods/firstboot~' -i /boot/cmdline.txt
+  sed 's~$~ init=/usr/lib/raspberrypi-sys-mods/firstboot~' -i /boot/cmdline.txt
 fi
 
-sudo shutdown now
+shutdown now


### PR DESCRIPTION
This PR adds a package which provides a script overlaid into `/usr/libexec/prepare-custom-image` which can be run in order to reset machine-specific files on the filesystem and modify `/boot/cmdline.txt` in preparation for cloning the filesystem as an SD card image to be flashed to multiple other SD cards. When the script starts, it unmounts filesystem overlays for `/etc` and `/usr` (by stopping the corresponding systemd services); when the script ends, it shuts down the Raspberry Pi.