### PR TITLE
Add feature flag for grafana CPU limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- `core/apps/grafana`: added a `cpu-limit` feature flag to limit the CPU usage of the Grafana dashboard, to prevent CPU starvation for other processes.
+
 ## v2024.0.0-beta.1 - 2024-06-24
 
 ### Changed

--- a/core/apps/grafana/compose-cpu-limit.yml
+++ b/core/apps/grafana/compose-cpu-limit.yml
@@ -1,0 +1,3 @@
+services:
+  server:
+    cpus: 1

--- a/core/apps/grafana/forklift-package.yml
+++ b/core/apps/grafana/forklift-package.yml
@@ -75,3 +75,6 @@ features:
           protocol: http
           paths:
             - /admin/grafana/d/host-summary/*
+  cpu-limit:
+    description: Limits the dashboard's CPU usage to at most one virtual core.
+    compose-files: [compose-cpu-limit.yml]


### PR DESCRIPTION
This PR adds an optional feature flag to the Grafana app package for limiting the CPU usage of the app, in response to a [report](https://planktoscope.slack.com/archives/C01V5ENKG0M/p1723468284289069) by @tpollina of nontrivial CPU usage by Grafana after it's opened for the first time after boot.