### PR TITLE
Bump device-portal and docs for v3 protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - `core/apps/planktoscope/device-portal`: the `ghcr.io/planktoscope/device-portal` container is upgraded from v0.2.3 to v0.2.4.
 - `core/apps/planktoscope/docs`: the `ghcr.io/planktoscope/project-docs` container is upgraded.
 
+### Fixed
+- `core/host/machine-name`: the `update-hostname` systemd service provided by this package now explicitly starts before the `avahi-daemon` systemd service, so that Avahi correctly registers the device as `pkscope-{machine-name}.local` instead of registering it as `raspberrypi.local` (based on the default hostname).
+
 ## v2024.0.0-beta.2 - 2024-09-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Changed
+
+- `core/apps/planktoscope/device-portal`: the `ghcr.io/planktoscope/device-portal` container is upgraded from v0.2.3 to v0.2.4.
+- `core/apps/planktoscope/docs`: the `ghcr.io/planktoscope/project-docs` container is upgraded.
+
 ## v2024.0.0-beta.2 - 2024-09-19
 
 ### Added

--- a/core/apps/planktoscope/device-portal/compose.yml
+++ b/core/apps/planktoscope/device-portal/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/device-portal:0.2.3
+    image: ghcr.io/planktoscope/device-portal:0.2.4
 
 networks:
   default:

--- a/core/apps/planktoscope/docs/compose-full-site.yml
+++ b/core/apps/planktoscope/docs/compose-full-site.yml
@@ -1,3 +1,3 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:sha-e568244
+    image: ghcr.io/planktoscope/project-docs:sha-087e173

--- a/core/apps/planktoscope/docs/compose-full-site.yml
+++ b/core/apps/planktoscope/docs/compose-full-site.yml
@@ -1,3 +1,3 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:sha-a05e0e3
+    image: ghcr.io/planktoscope/project-docs:sha-e568244

--- a/core/apps/planktoscope/docs/compose-full-site.yml
+++ b/core/apps/planktoscope/docs/compose-full-site.yml
@@ -1,3 +1,3 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:2024.0.0-beta.2
+    image: ghcr.io/planktoscope/project-docs:sha-a05e0e3

--- a/core/apps/planktoscope/docs/compose.yml
+++ b/core/apps/planktoscope/docs/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:sha-a05e0e3-minimal
+    image: ghcr.io/planktoscope/project-docs:sha-e568244-minimal
     volumes:
       - server-data:/data
       - server-config:/config

--- a/core/apps/planktoscope/docs/compose.yml
+++ b/core/apps/planktoscope/docs/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:sha-e568244-minimal
+    image: ghcr.io/planktoscope/project-docs:sha-087e173-minimal
     volumes:
       - server-data:/data
       - server-config:/config

--- a/core/apps/planktoscope/docs/compose.yml
+++ b/core/apps/planktoscope/docs/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:2024.0.0-beta.2-minimal
+    image: ghcr.io/planktoscope/project-docs:sha-a05e0e3-minimal
     volumes:
       - server-data:/data
       - server-config:/config

--- a/core/host/machine-name/overlays/usr/lib/systemd/system/generate-hostname-templated.service
+++ b/core/host/machine-name/overlays/usr/lib/systemd/system/generate-hostname-templated.service
@@ -8,7 +8,6 @@ After=local-fs.target
 Wants=generate-machine-name.service
 After=generate-machine-name.service
 Before=systemd-hostnamed.service
-Before=avahi-daemon.service
 Before=sysinit.target
 
 [Service]

--- a/core/host/machine-name/overlays/usr/lib/systemd/system/generate-hostname-templated.service
+++ b/core/host/machine-name/overlays/usr/lib/systemd/system/generate-hostname-templated.service
@@ -8,6 +8,7 @@ After=local-fs.target
 Wants=generate-machine-name.service
 After=generate-machine-name.service
 Before=systemd-hostnamed.service
+Before=avahi-daemon.service
 Before=sysinit.target
 
 [Service]

--- a/core/host/machine-name/overlays/usr/lib/systemd/system/update-hostname.service
+++ b/core/host/machine-name/overlays/usr/lib/systemd/system/update-hostname.service
@@ -7,6 +7,7 @@ Requires=systemd-hostnamed.service
 After=systemd-hostnamed.service
 Wants=network-pre.target
 Before=network-pre.target
+Before=avahi-daemon.service
 
 [Service]
 Type=oneshot

--- a/core/host/networking/avahi-daemon/overlays/usr/lib/systemd/system/planktoscope-mdns-alias@.service
+++ b/core/host/networking/avahi-daemon/overlays/usr/lib/systemd/system/planktoscope-mdns-alias@.service
@@ -7,6 +7,8 @@ Wants=avahi-daemon.socket
 [Service]
 Type=simple
 ExecStart=/usr/bin/bash -c "/usr/bin/avahi-publish -a -R %i.local 192.168.4.1"
+# FIXME: replace this with a package to generate a /etc/avahi/hosts file from
+# a /etc/avahi/hosts.d directory, just like how we generate /etc/hosts!
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR integrates https://github.com/PlanktoScope/device-portal/pull/175 and https://github.com/PlanktoScope/device-portal/pull/176 .

This PR also fixes a bug with Avahi handling of `pkscope-{machine-name}.local` so that that domain name is actually handled (instead of handling `raspberrypi.local`). That bug was probably a regression caused by #9 .

Note: the changes in this PR will need to be duplicated into the main branch of the pallet-standard repo.