### PR TITLE
Add a toggle for DHCP default route advertisement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- `core/host/networking/interface-forwarding`: added a `planktoscope-dhcp-default-route` feature flag to configure the DHCP server to advertise the PlanktoScope as a default route to the internet.
+- `core/host/networking/interface-forwarding`: the default deployment now configures dnsmasq to advertise the PlanktoScope as a route to all IP addresses in 192.168.3.\*, 192.168.4.\*, 192.168.5.\*, 192.168.6.\*, and 192.168.7.\*, so that connected devices will now try to reach the PlanktoScope at 192.168.3.1, 192.168.4.1, ..., 192.168.7.1 even if the PlanktoScope doesn't advertise itself as a default route to the internet.
+
+### Removed
+
+- (Breaking change) `core/host/networking/dnsmasq`: the DHCP server no longer advertises the PlanktoScope as a default route to the internet, since this breaks internet access on certain (macOS/Windows) client devices connected simultaneously to a Wi-Fi network for internet access and to a PlanktoScope via Ethernet. To restore this functionality, enable the new `planktoscope-dhcp-default-route` feature flag which has now been added to the `core/host/networking/interface-forwarding` package.
+
 ## v2024.0.0-beta.3 - 2024-11-30
 
 ### Changed
@@ -146,7 +157,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ### Fixed
 
-- Removed unnamed volumes created by the packages for filebrowser instances and for mosquitto.
+- Removed unnamed volumes created by the packages for filebrowser instances and for mosquito.
 - Changed underscores to hyphens in Docker volume names, for consistency with Docker network names.
 
 ## v2023.9.0 - 2023-12-30

--- a/core/apps/planktoscope/docs/compose-full-site.yml
+++ b/core/apps/planktoscope/docs/compose-full-site.yml
@@ -1,3 +1,3 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:2024.0.0-beta.3
+    image: ghcr.io/planktoscope/project-docs:sha-776c201

--- a/core/apps/planktoscope/docs/compose.yml
+++ b/core/apps/planktoscope/docs/compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/planktoscope/project-docs:2024.0.0-beta.3-minimal
+    image: ghcr.io/planktoscope/project-docs:sha-776c201-minimal
     volumes:
       - server-data:/data
       - server-config:/config

--- a/core/host/networking/dnsmasq/forklift-package.yml
+++ b/core/host/networking/dnsmasq/forklift-package.yml
@@ -66,12 +66,14 @@ deployment:
 features:
   planktoscope-dhcp-interfaces:
     description:
-      Enable DHCP & DNS server functionality for the PlanktoScope OS's static IP address
-      assignments on its network interfaces
+      Enable DHCP server functionality for the PlanktoScope OS's static IP address assignments on
+      its network interfaces
     provides:
       file-exports:
         - description:
-            Sets DHCP & DNS server settings on the wlan0, wlan1, eth0, eth1, and usb0 interfaces
+            Set DHCP server settings to assign IP addresses on the wlan0, wlan1, eth0, eth1, and
+            usb0 interfaces and to *not* advertise the PlanktoScope as a default route to the
+            internet
           target: overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
   custom-domain:
     description: Handle DNS requests for a custom domain set by /etc/custom-domain

--- a/core/host/networking/dnsmasq/overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
+++ b/core/host/networking/dnsmasq/overlays/etc/dnsmasq.d/30-dhcp-interfaces.conf
@@ -4,21 +4,46 @@ localise-queries
 
 interface=wlan1
 dhcp-range=wlan1,192.168.3.64,192.168.3.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=wlan1,option:router
+# Note: the following line is probably unnecessary, and it will be removed in a future version of
+# this file:
 dhcp-option=wlan1,option:dns-server,192.168.3.1
 
 interface=wlan0
 dhcp-range=wlan0,192.168.4.64,192.168.4.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=wlan0,option:router
+# Note: the following line is probably unnecessary, and it will be removed in a future version of
+# this file:
 dhcp-option=wlan0,option:dns-server,192.168.4.1
 
 interface=eth0
 dhcp-range=eth0,192.168.5.64,192.168.5.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=eth0,option:router
+# Note: the following line is probably unnecessary, and it will be removed in a future version of
+# this file:
 dhcp-option=eth0,option:dns-server,192.168.5.1
 
 interface=usb0
 dhcp-range=usb0,192.168.6.64,192.168.6.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=usb0,option:router
+# Note: the following line is probably unnecessary, and it will be removed in a future version of
+# this file:
 dhcp-option=usb0,option:dns-server,192.168.6.1
 
 interface=eth1
 dhcp-range=eth1,192.168.7.64,192.168.7.254,12h
+# Don't advertise ourselves as handling the default route, since we can't guarantee that we can
+# route to the internet:
+dhcp-option=eth1,option:router
+# Note: the following line is probably unnecessary, and it will be removed in a future version of
+# this file:
 dhcp-option=eth1,option:dns-server,192.168.7.1
 

--- a/core/host/networking/interface-forwarding/forklift-package.yml
+++ b/core/host/networking/interface-forwarding/forklift-package.yml
@@ -19,7 +19,7 @@ deployment:
       - description: systemd service enablement for enable-interface-forwarding.service
         target: overlays/etc/systemd/system/network-online.target.wants/enable-interface-forwarding.service
       - description:
-          DnsMasq configuration to advertise the PlanktoScope as a route to all IP addresses
+          dnsmasq configuration to advertise the PlanktoScope as a route to all IP addresses
           assigned by the PlanktoScope to devices connected on all interfaces.
         target: overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
 

--- a/core/host/networking/interface-forwarding/forklift-package.yml
+++ b/core/host/networking/interface-forwarding/forklift-package.yml
@@ -18,3 +18,16 @@ deployment:
         target: overlays/usr/lib/systemd/system/enable-interface-forwarding.service
       - description: systemd service enablement for enable-interface-forwarding.service
         target: overlays/etc/systemd/system/network-online.target.wants/enable-interface-forwarding.service
+      - description:
+          DnsMasq configuration to advertise the PlanktoScope as a route to all IP addresses
+          assigned by the PlanktoScope to devices connected on all interfaces.
+        target: overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
+
+features:
+  planktoscope-dhcp-default-route:
+    description:
+      Configure dnsmasq's DHCP server to advertise itself as a default route to the internet
+    provides:
+      file-exports:
+        - description: Sets DHCP settings on the wlan0, wlan1, eth0, eth1, and usb0 interfaces
+          target: overlays/etc/dnsmasq.d/35-dhcp-default-route.conf

--- a/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-default-route.conf
+++ b/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-default-route.conf
@@ -1,0 +1,17 @@
+# Advertise ourselves as a default route to the internet.
+
+interface=wlan1
+dhcp-option=wlan1,option:router,0.0.0.0
+
+interface=wlan0
+dhcp-option=wlan0,option:router,0.0.0.0
+
+interface=eth0
+dhcp-option=eth0,option:router,0.0.0.0
+
+interface=usb0
+dhcp-option=usb0,option:router,0.0.0.0
+
+interface=eth1
+dhcp-option=eth1,option:router,0.0.0.0
+

--- a/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
+++ b/core/host/networking/interface-forwarding/overlays/etc/dnsmasq.d/35-dhcp-subnet-routes.conf
@@ -1,0 +1,17 @@
+# Advertise ourselves as a route for addresses on 192.168.*.*, even if we're not a default route.
+
+interface=wlan1
+dhcp-option=wlan1,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=wlan0
+dhcp-option=wlan0,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=eth0
+dhcp-option=eth0,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=usb0
+dhcp-option=usb0,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+
+interface=eth1
+dhcp-option=eth1,option:classless-static-route,192.168.3.0/24,0.0.0.0,192.168.4.0/24,0.0.0.0,192.168.5.0/24,0.0.0.0,192.168.6.0/24,0.0.0.0,192.168.7.0/24,0.0.0.0
+


### PR DESCRIPTION
This PR is part of a workaround for https://github.com/PlanktoScope/PlanktoScope/issues/201. Specifically, it moves the PlanktoScope's advertisement of itself as a default route to the internet from default behavior into a new `planktoscope-dhcp-default-route` feature flag provided by the `core/host/networking/interface-forwarding` package. Regardless of whether that feature flag is enabled, the PlanktoScope can still resolve IP addresses such as 192.168.4.1 and 192.168.5.1 from any connected interface.